### PR TITLE
Fix json_decode() fallback function

### DIFF
--- a/upload/system/helper/json.php
+++ b/upload/system/helper/json.php
@@ -123,6 +123,6 @@ if (!function_exists('json_decode')) {
 
 		$json = strtr($json, array_map('stripcslashes', $m2s));
 
-		return eval('return {'.$json.'}');
+		return eval('return '.$json.';');
 	}
 }


### PR DESCRIPTION
I read the original code wrong and didn't have time to test it. This should fix things. Though I would recommend fully removing this function, it looks risky and i doubt that any modern installation of php does not have json_decode() build in.