### PR TITLE
Adjust code style rule

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -170,7 +170,6 @@ return $config
         'types_spaces' => true,
         'unary_operator_spaces' => true,
         'use_arrow_functions' => true,
-        'void_return' => true,
         'whitespace_after_comma_in_array' => true,
         'yield_from_array_to_yields' => true,
     ])


### PR DESCRIPTION
Remove the rule for adding void return to functions that do not have it, as I'm guessing this would not be a good fit for the goal of this repo. If you do intend to add return types to all functions you can just close this PR, but I was interested to see how close to the code style things are at this point :)