### PR TITLE
Document basic object relations in a way that can be parsed by PHPStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,10 @@
         "php": ">=7.4.0",
         "ext-curl": "*",
         "ext-zip": "*"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tools\\PHPStan\\": "tools/phpstan/"
+        }
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,10 +1,15 @@
+services:
+    -
+        class: \Tools\PHPStan\RegistryPropertyReflectionExtension
+        tags:
+            - phpstan.broker.propertiesClassReflectionExtension
 parameters:
     level: 1
     paths:
         - ./upload/
     excludePaths:
-        - ./system/storage/vendor/
         - ./upload/system/storage/vendor/
     tmpDir: .cache
     ignoreErrors:
         - '#Class Event constructor invoked with 1 parameter, 4-5 required\.#'
+        - '#Constant [A-Z_]+ not found\.#'

--- a/tools/phpstan/LoadedProperty.php
+++ b/tools/phpstan/LoadedProperty.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tools\PHPStan;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\PropertyReflection;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\Type;
+
+class LoadedProperty implements PropertyReflection {
+	/**
+	 * @var ClassReflection
+	 */
+	private $declaringClass;
+	/**
+	 * @var Type
+	 */
+	private $type;
+
+	public function __construct(ClassReflection $declaringClass, Type $readableType) {
+		$this->declaringClass = $declaringClass;
+		$this->type = $readableType;
+	}
+
+	public function getDeclaringClass(): ClassReflection {
+		return $this->declaringClass;
+	}
+
+	public function isStatic(): bool {
+		return false;
+	}
+
+	public function isPrivate(): bool {
+		return false;
+	}
+
+	public function isPublic(): bool {
+		return true;
+	}
+
+	public function isReadable(): bool {
+		return true;
+	}
+
+	public function isWritable(): bool {
+		return false;
+	}
+
+	public function getDocComment(): ?string {
+		return null;
+	}
+
+	public function getReadableType(): Type {
+		return $this->type;
+	}
+
+	public function getWritableType(): Type {
+		return new NeverType();
+	}
+
+	public function canChangeTypeAfterAssignment(): bool {
+		return false;
+	}
+
+	public function isDeprecated(): TrinaryLogic {
+		return TrinaryLogic::createNo();
+	}
+
+	public function getDeprecatedDescription(): ?string {
+		return null;
+	}
+
+	public function isInternal(): TrinaryLogic {
+		return TrinaryLogic::createNo();
+	}
+}

--- a/tools/phpstan/RegistryPropertyReflectionExtension.php
+++ b/tools/phpstan/RegistryPropertyReflectionExtension.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tools\PHPStan;
+
+use Registry;
+use PHPStan\Broker\Broker;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\PropertiesClassReflectionExtension;
+use PHPStan\Reflection\PropertyReflection;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\TypeCombinator;
+
+class RegistryPropertyReflectionExtension implements PropertiesClassReflectionExtension {
+	public function hasProperty(ClassReflection $classReflection, string $propertyName): bool {
+		if (!$classReflection->is(Registry::class)) {
+			return false;
+		}
+
+		return preg_match('/^model_.+$/', $propertyName, $matches) === 1;
+	}
+
+	public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection {
+		preg_match('/^(model_.+)$/', $propertyName, $matches);
+		$className = $this->convertSnakeToStudly($matches[1]);
+
+		$broker = Broker::getInstance();
+
+		$type = null;
+		if ($broker->hasClass($className)) {
+			$found = new ObjectType($className);
+			if ($classType === 'Model') {
+				$found = new GenericObjectType('\Proxy', [$found]);
+			}
+			$type = $type ? TypeCombinator::union($type, $found) : $found;
+		}
+		if ($type) {
+			$type = TypeCombinator::addNull($type);
+		} else {
+			$type = new NullType();
+		}
+
+		return new LoadedProperty($classReflection, $type);
+	}
+
+	private function convertSnakeToStudly(string $value): string {
+		return str_replace(' ', '', ucwords(str_replace('_', ' ', $value)));
+	}
+}

--- a/tools/phpstan/RegistryPropertyReflectionExtension.php
+++ b/tools/phpstan/RegistryPropertyReflectionExtension.php
@@ -27,16 +27,11 @@ class RegistryPropertyReflectionExtension implements PropertiesClassReflectionEx
 
 		$broker = Broker::getInstance();
 
-		$type = null;
+		$type = new NullType();
 		if ($broker->hasClass($className)) {
 			$found = new ObjectType($className);
-			$found = new GenericObjectType('\Proxy', [$found]);
-			$type = $type ? TypeCombinator::union($type, $found) : $found;
-		}
-		if ($type) {
+			$type = new GenericObjectType('\Proxy', [$found]);
 			$type = TypeCombinator::addNull($type);
-		} else {
-			$type = new NullType();
 		}
 
 		return new LoadedProperty($classReflection, $type);

--- a/tools/phpstan/RegistryPropertyReflectionExtension.php
+++ b/tools/phpstan/RegistryPropertyReflectionExtension.php
@@ -30,9 +30,7 @@ class RegistryPropertyReflectionExtension implements PropertiesClassReflectionEx
 		$type = null;
 		if ($broker->hasClass($className)) {
 			$found = new ObjectType($className);
-			if ($classType === 'Model') {
-				$found = new GenericObjectType('\Proxy', [$found]);
-			}
+			$found = new GenericObjectType('\Proxy', [$found]);
 			$type = $type ? TypeCombinator::union($type, $found) : $found;
 		}
 		if ($type) {

--- a/upload/system/engine/controller.php
+++ b/upload/system/engine/controller.php
@@ -11,6 +11,8 @@
 
 /**
  * Controller class
+ *
+ * @mixin Registry
  */
 abstract class Controller {
 	protected $registry;

--- a/upload/system/engine/model.php
+++ b/upload/system/engine/model.php
@@ -11,14 +11,19 @@
 
 /**
  * Model class
+ *
+ * @mixin Registry
  */
 class Model {
+	/**
+	 * @var Registry
+	 */
 	protected $registry;
 
 	/**
 	 * Constructor
 	 *
-	 * @param object $registry
+	 * @param Registry $registry
 	 */
 	public function __construct($registry) {
 		$this->registry = $registry;

--- a/upload/system/engine/proxy.php
+++ b/upload/system/engine/proxy.php
@@ -11,6 +11,10 @@
 
 /**
  * Proxy class
+ *
+ * @template TWraps of Model
+ *
+ * @mixin TWraps
  */
 class Proxy extends \stdClass {
 	protected $data = [];

--- a/upload/system/engine/registry.php
+++ b/upload/system/engine/registry.php
@@ -11,16 +11,44 @@
 
 /**
  * Registry class
- */
-
-/**
- * Class Registry
  *
- * @property \Admin\Controller\Catalog\Attribute $load
+ * @property Cache          $cache
+ * @property Cart\Affiliate $affiliate
+ * @property Cart\Cart      $cart
+ * @property Cart\Currency  $currency
+ * @property Cart\Customer  $customer
+ * @property Cart\Length    $length
+ * @property Cart\Tax       $tax
+ * @property ?Cart\User     $user
+ * @property Cart\Weight    $weight
+ * @property Config         $config
+ * @property DB             $db
+ * @property Document       $document
+ * @property Encryption     $encryption
+ * @property Event          $event
+ * @property Language       $language
+ * @property Loader         $load
+ * @property Log            $log
+ * @property Request        $request
+ * @property Response       $response
+ * @property Session        $session
+ * @property Url            $url
  */
-
 class Registry {
 	private $data = [];
+
+	/**
+	 * __get
+	 *
+	 * https://www.php.net/manual/en/language.oop5.overloading.php#object.get
+	 *
+	 * @param string $key
+	 *
+	 * @return ?object
+	 */
+	public function __get(string $key): ?object {
+		return $this->get($key);
+	}
 
 	/**
 	 * Get


### PR DESCRIPTION
This makes it possible for PHPStan to discover most magic symbols, lowering the number of issues on level 1 from 43875 to 186 which is more feasible to solve...

This does make a lot of assumptions, but OC is build on a lot of assumptions so there isn't really any way around it short of making OC5